### PR TITLE
Editing CMakeLists.txt functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,166 +1,84 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(discreture)
-enable_language(C CXX)
+##
+## PROJECT
+## name and version
+project(discreture VERSION 1.7 LANGUAGES CXX)
 
-if (NOT CMAKE_BUILD_TYPE)
-    message("CMAKE_BUILD_TYPE not specified! Setting to Release.")
-    set(CMAKE_BUILD_TYPE "Release")
-endif()
+##
+## INCLUDE
+##
+##
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+include(ExternalProject)
+include(CodeCoverage)
+include(ConfigSafeGuards)
+include(Colors)
 
-option(BUILD_EXAMPLES "Build examples" ON)
+##
+## OPTIONS
+##
+option(BUILD_EXAMPLES "Build examples" OFF)
 option(BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(BUILD_TESTS "Build unit tests" OFF)
-option(BUILD_OWN_GOOGLETEST "Build own google's unit testing framework, even if found" OFF)
+
+##
+## CONFIGURATION
+##
+set(DISCRETURE_TARGET_NAME              ${PROJECT_NAME})
+set(DISCRETURE_TARGETS_EXPORT_NAME      "${PROJECT_NAME}Targets")
+set(DISCRETURE_CMAKE_CONFIG_DIR         "${CMAKE_CURRENT_BINARY_DIR}")
+set(DISCRETURE_CMAKE_PROJECT_TARGETS_FILE       "${DISCRETURE_CMAKE_CONFIG_DIR}/${PROJECT_NAME}Targets.cmake")
+
+##
+## TARGET
+## create target and add include path
+##
+add_library(${DISCRETURE_TARGET_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${DISCRETURE_TARGET_NAME} ALIAS ${DISCRETURE_TARGET_NAME})
+
+find_package(Boost REQUIRED)
+
+target_include_directories(
+    ${DISCRETURE_TARGET_NAME}
+    INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(
+    ${DISCRETURE_TARGET_NAME}
+    INTERFACE
+    cxx_std_14
+)
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)
 if (cmake_build_type_tolower STREQUAL "coverage")
     set(BUILD_TESTS ON)
 endif()
 
-find_package(Boost REQUIRED)
-find_package(Threads)
-
-set(PROJECT_VERSION_MAJOR 1)
-set(PROJECT_VERSION_MINOR 7)
-
-
-# Include stuff. No change needed.
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
-include(ConfigSafeGuards)
-include(Colors)
-
-set(CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-
-# Build-type specific flags. Change as needed.
-message("Compiler used: " ${CMAKE_CXX_COMPILER_ID})
-if (MSVC)
-# 	message("Using msvc")
-else()
-# 	message("Not using MSVC")
-	SET(CMAKE_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG -ffast-math")
-	SET(CMAKE_CXX_FLAGS_DEBUG "-g -O1 -Wall -Wextra -Wpedantic -Wno-unused -Wno-sign-compare")
-	if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
-		message("Extra flags for RELEASE: " ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE})
-	else()
-		message("Extra flags for DEBUG: "  ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG})		
-	endif()
-endif() # Help wanted: what to do if MSVC? Does it compile? I have no idea and no way to test!
-
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
-
-
-if(${BUILD_TESTS})
-    find_package(GTest)
-    find_package(Threads REQUIRED)
-    set(TEST_LIB googletest)
-    set(TEST_FILES  tests/main.cpp
-                    tests/sequence_tests.cpp
-                    tests/integer_interval_tests.cpp
-                    tests/arithmetic_progression_tests.cpp
-                    tests/combination_tests.cpp
-                    tests/lex_combinations_tests.cpp
-                    tests/permutation_tests.cpp
-                    tests/multiset_tests.cpp
-                    tests/dyck_tests.cpp
-                    tests/motzkin_tests.cpp
-                    tests/partition_tests.cpp
-                    tests/set_partition_tests.cpp
-                    tests/idxview_tests.cpp
-                    tests/idxview_container_tests.cpp
-                    tests/reversed_tests.cpp
-        )
-    set(TEST_MAIN unit_tests.x)
-	if (${GTEST_FOUND} AND NOT ${BUILD_OWN_GOOGLETEST})
-        include_directories(${GTEST_INCLUDE_DIRS})
-        set(TEST_LIB ${GTEST_BOTH_LIBRARIES})
-        add_executable(${TEST_MAIN} ${TEST_FILES})
-	else()
-		message("Google testing framework not found. Building our own!")
-        add_custom_target( git_update
-        COMMAND git submodule init
-        COMMAND git submodule update
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} )
-		include_directories(
-							${PROJECT_SOURCE_DIR}/external/googletest/googletest/
-							${PROJECT_SOURCE_DIR}/external/googletest/googletest/include)
-        add_library(googletest
-            ${PROJECT_SOURCE_DIR}/external/googletest/googletest/src/gtest-all.cc
-            ${PROJECT_SOURCE_DIR}/external/googletest/googletest/src/gtest_main.cc)
-        add_dependencies(googletest git_update)
-        set_source_files_properties(${PROJECT_SOURCE_DIR}/external/googletest/googletest/src/gtest-all.cc  PROPERTIES GENERATED 1)
-        set_source_files_properties(${PROJECT_SOURCE_DIR}/external/googletest/googletest/src/gtest_main.cc PROPERTIES GENERATED 1)
-        add_executable(${TEST_MAIN} ${TEST_FILES})
-        add_dependencies(${TEST_MAIN} ${TEST_LIB})
-    endif()
-    
-    target_link_libraries(${TEST_MAIN} ${TEST_LIB} ${CMAKE_THREAD_LIBS_INIT})
-    add_custom_target(gtest COMMAND "${PROJECT_BINARY_DIR}/${TEST_MAIN}" DEPENDS ${TEST_MAIN})
-
-    # Add a standard make target 'test' that runs the tests under CTest (only as an alt. to gtest).
-    include(CTest)
+if(BUILD_TESTS)
     enable_testing()
-    add_test(unit_tests ${PROJECT_BINARY_DIR}/${TEST_MAIN})
+    add_subdirectory(tests)
 endif()
 
-
-# --------------------------------------------------------------------------------
-#                            Build!
-# --------------------------------------------------------------------------------
-if(${BUILD_EXAMPLES})
-	add_executable(combinations examples/combinations.cpp)
-	add_executable(combinations_reverse examples/combinations_reverse.cpp)
-	add_executable(lex_combinations examples/lex_combinations.cpp)
-	add_executable(lex_combinations_reverse examples/lex_combinations_reverse.cpp)
-	add_executable(dyck examples/dyck.cpp)
-	add_executable(motzkin examples/motzkin.cpp)
-	add_executable(permutations examples/permutations.cpp)
-	add_executable(arithmetic_progression examples/arithmetic_progression.cpp)
-	add_executable(setpartitions examples/setpartitions.cpp)
-	add_executable(partitions examples/partitions.cpp)
-	add_executable(partitions_reverse examples/partitions_reverse.cpp)
-	add_executable(multisets examples/multisets.cpp)
-	add_executable(playground examples/playground.cpp)
-	add_executable(tutorial examples/tutorial.cpp)
-    if (${CMAKE_USE_PTHREADS_INIT})
-        add_executable(tutorial_parallel examples/tutorial_parallel.cpp)
-        target_link_libraries(tutorial_parallel ${CMAKE_THREAD_LIBS_INIT})
-	endif()
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
 endif()
 
 if(BUILD_BENCHMARKS)
-	find_package(GSL)
-	if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-		add_definitions("-mtune=native")
-	endif()
-	if (${GSL_FOUND})
-		add_definitions(-DTEST_GSL_COMBINATIONS)
-		include_directories(${GSL_INCLUDE_DIRS})
-	endif()
-	add_executable(benchmark_discreture benchmarks/main.cpp
-                                        benchmarks/combs.cpp
-                                        benchmarks/perms.cpp
-                                        benchmarks/multisets.cpp
-                                        benchmarks/dyckmotzkin.cpp
-                                        benchmarks/partitions.cpp
-                                        )
-    if (GSL_FOUND)
-		target_link_libraries(benchmark_discreture ${GSL_LIBRARIES})
-	endif()
-    
-    if (${CMAKE_USE_PTHREADS_INIT})
-        add_executable(benchmark_parallel benchmarks/parallel/parallel_benchmarks.cpp)
-        target_link_libraries(benchmark_parallel ${CMAKE_THREAD_LIBS_INIT})
-	endif()
-
-	
+    add_subdirectory(benchmarks)
 endif()
 
-include(CodeCoverage)
 
-set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
-
+##
+## INSTALL
+## create target and add include path
+##
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/)
+export(
+    TARGETS     ${DISCRETURE_TARGET_NAME}
+    NAMESPACE   ${PROJECT_NAME}::
+    FILE        ${DISCRETURE_CMAKE_PROJECT_TARGETS_FILE}
+)
+

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,61 @@
+
+cmake_minimum_required(VERSION 3.0)
+
+##
+## PROJECT
+## name and version
+project(discreture_benchmarks LANGUAGES CXX)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+add_executable(
+    benchmark_discreture 
+    main.cpp
+    combs.cpp
+    perms.cpp
+    multisets.cpp
+    dyckmotzkin.cpp
+    partitions.cpp
+)
+
+target_link_libraries(
+    benchmark_discreture 
+    PRIVATE discreture::discreture
+)
+
+find_package(GSL)
+
+if (NOT CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(
+        benchmark_discreture
+        PRIVATE "-mtune=native"
+    )
+endif()
+
+if (GSL_FOUND)
+
+    target_compile_definitions(
+        benchmark_discreture
+        PRIVATE "-DTEST_GSL_COMBINATIONS"
+    )
+
+    target_include_directories(
+        benchmark_discreture
+        PRIVATE ${GSL_INCLUDE_DIRS}
+    )
+
+	target_link_libraries(
+        benchmark_discreture 
+        PRIVATE ${GSL_LIBRARIES}
+    )
+
+endif()
+
+if (${CMAKE_USE_PTHREADS_INIT})
+    add_executable(
+        benchmark_parallel 
+        benchmarks/parallel/parallel_benchmarks.cpp)
+    target_link_libraries(
+        benchmark_parallel 
+        PRIVATE ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,61 @@
+
+cmake_minimum_required(VERSION 3.0)
+
+##
+## PROJECT
+## name and version
+project(discreture_examples LANGUAGES CXX)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+find_package(Threads)
+
+set(RELEASE_COMPILE_FLAGS "-Ofast -DNDEBUG -ffast-math")
+set(DEBUG_COMPILE_FLAGS "-g -O1 -Wall -Wextra -Wpedantic -Wno-unused -Wno-sign-compare")
+
+function(build_test TEST_SRC)
+	get_filename_component(test_src_we ${TEST_SRC} NAME_WE)
+	set(target "${test_src_we}")
+	add_executable(${target} ${TEST_SRC})
+	target_link_libraries(
+		${target}
+		discreture::discreture
+	)
+	target_compile_options(
+		${target}
+		PRIVATE
+		$<$<CONFIG:Debug>:${DEBUG_COMPILE_FLAGS}>
+		$<$<CONFIG:Release>:${RELEASE_COMPILE_FLAGS}>
+	)
+endfunction(build_test)
+
+set(
+	TEST_SRCS
+	combinations.cpp
+	combinations_reverse.cpp
+	lex_combinations.cpp
+	lex_combinations_reverse.cpp
+	dyck.cpp
+	motzkin.cpp
+	permutations.cpp
+	arithmetic_progression.cpp
+	setpartitions.cpp
+	partitions.cpp
+	partitions_reverse.cpp
+	multisets.cpp
+	playground.cpp
+	tutorial.cpp
+)
+
+foreach(test_src ${TEST_SRCS})
+	build_test(${test_src})
+endforeach(test_src)
+
+if (${CMAKE_USE_PTHREADS_INIT})
+    add_executable(tutorial_parallel tutorial_parallel.cpp)
+    target_link_libraries(
+		tutorial_parallel
+		discreture::discreture
+	)
+    target_link_libraries(tutorial_parallel ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,69 @@
+
+cmake_minimum_required(VERSION 3.0)
+
+##
+## PROJECT
+## name and version
+project(discreture_tests LANGUAGES CXX)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+find_package(Threads REQUIRED)
+
+set(RELEASE_COMPILE_FLAGS "-Ofast -DNDEBUG -ffast-math")
+set(DEBUG_COMPILE_FLAGS "-g -O1 -Wall -Wextra -Wpedantic -Wno-unused -Wno-sign-compare")
+
+add_subdirectory(${CMAKE_SOURCE_DIR}/external/googletest "external/googletest")
+
+set(TEST_FILES
+	main.cpp
+    sequence_tests.cpp
+    integer_interval_tests.cpp
+    arithmetic_progression_tests.cpp
+    combination_tests.cpp
+    lex_combinations_tests.cpp
+    permutation_tests.cpp
+    multiset_tests.cpp
+    dyck_tests.cpp
+    motzkin_tests.cpp
+    partition_tests.cpp
+    set_partition_tests.cpp
+    idxview_tests.cpp
+    idxview_container_tests.cpp
+    reversed_tests.cpp
+)
+
+set(TEST_MAIN unit_tests.x)
+add_executable(${TEST_MAIN} ${TEST_FILES})
+
+message("PROJECT_SOURCE_DIR: ${PROJECT_SOURCE_DIR}")
+
+function(build_test SRC_FILE)
+    get_filename_component(src_name_we ${SRC_FILE} NAME_WE)
+    set(target "${src_name_we}")
+    add_executable(${target} ${SRC_FILE})
+    add_dependencies(${target} gtest)
+    target_link_libraries(
+        ${target}
+        ${CMAKE_THREAD_LIBS_INIT}
+        discreture::discreture
+        gtest
+        gmock
+        gtest_main
+    )
+    target_compile_options(
+        ${target}
+        PRIVATE
+        $<$<CONFIG:Debug>:${DEBUG_COMPILE_FLAGS}>
+        $<$<CONFIG:Release>:${RELEASE_COMPILE_FLAGS}>
+    )
+    add_test(${target} ${target})
+endfunction(build_test)
+
+foreach(test_src ${TEST_FILES})
+    build_test(${test_src})
+endforeach(test_src)
+
+# Add a standard make target 'test' that runs the tests under CTest (only as an alt. to gtest).
+include(CTest)
+add_test(unit_tests ${PROJECT_BINARY_DIR}/${TEST_MAIN})


### PR DESCRIPTION
Changes enable project to work with add_subdirectory when project is added as a subdirectory. Also split up the various build options to separate CMakeLists as most people would just add it for the header-only functionality. Fixed leaking of various flag settings from propagating upstream